### PR TITLE
Add link check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,45 @@
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl make libxml2-dev libxslt-dev openssl
+      - name: Setup snaps
+        run: |
+          sudo snap install yq
+          sudo snap install aws-cli --classic
+          sudo snap install node --classic --channel=10/stable
+      - name: Use Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+          architecture: "x64"
+      - uses: actions/checkout@master
+      - name: Update gems
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Build site
+        run: |
+          make _site
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: --no-progress --exclude assets --exclude "file:" --exclude "javascript:" -- _site/**/*.html
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Create Issue From File
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
Fixes #30

This adds a Github workflow, which will use [lychee](https://github.com/lycheeverse/lychee) to check for broken links once per day.

**Notes:**

* I had to copy the existing `build` workflow to generate the site before checking. (Same as the `deploy` workflows.) I figured it would be easier this way instead of adding the link check to the end of a build, because it can be distracting from the changes in a pull request. Furthermore, link checking should be done regularly on the `master` branch as well, so I went ahead with a cronjob that runs once per day.
* The cron execution time can be adjusted of course. I found that it's best to do it during working hours, to be able to react in a timely fashion. ([Time is in UTC](https://jasonet.co/posts/scheduled-actions/).)
* The workflow can be triggered manually as well, which can be helpful for ad-hoc troubleshooting. 